### PR TITLE
Fix: Use generic icon for emitter category fallback — stop misrepresenting aircraft

### DIFF
--- a/html/markers.js
+++ b/html/markers.js
@@ -1240,11 +1240,11 @@ let TypeDescriptionIcons = {
 };
 
 let CategoryIcons = {
-    "A1" : ['cessna', 1],// < 7t
+    "A1" : ['unknown', 1],// < 7t
 
-    "A2" : ['jet_swept', 0.94], // < 34t
+    "A2" : ['unknown', 1], // < 34t
 
-    "A3" : ['airliner', 0.96], // < 136t
+    "A3" : ['unknown', 1], // < 136t
 
     "A4" : ['airliner', 1], // < 136t
 


### PR DESCRIPTION
## Problem

Aircraft without database or registration info (especially **PIA — Privacy ICAO Address** aircraft) fall back to emitter category-based icons. The current mapping assigns specific aircraft-type icons to broad emitter categories:

- **A1** (Light, <7t) → Cessna icon
- **A2** (Medium, <34t) → Swept jet icon
- **A3** (Large, <136t) → Airliner icon

This is **misrepresentative and dangerous** in this space:

- A **Phenom 300** using a PIA address shows as a **Cessna at 40,000 ft** — obviously wrong
- A **Gulfstream** (category A3) shows as an **airliner** — it is not
- An **ultralight jet** (category A1) shows as a **prop** — it is not

Emitter category only tells you the weight class, not the aircraft type. When there's no DB/reg data to resolve the actual type, guessing an icon based on weight class alone actively misleads users.

## Fix

Use the generic `unknown` icon with uniform scale (1.0) for A1, A2, and A3 fallback. This honestly represents "we don't know what this aircraft looks like" rather than displaying a confidently wrong icon.

## Why this matters

Misrepresenting aircraft types erodes trust in the platform and can mislead spotters, researchers, and safety-conscious users. An honest "unknown" is always better than a wrong guess. Don't end up like FlightRadar24.

---

<img width="1201" height="631" alt="PIA aircraft misrepresented with wrong icons" src="https://github.com/user-attachments/assets/519c8911-f33b-4d57-9f05-f9ea02a44d71" />