### PR TITLE
AX-957 - Remove aggregate feeder count from the public leaderboard

### DIFF
--- a/html/leaderboard/feeder-block.init.js
+++ b/html/leaderboard/feeder-block.init.js
@@ -213,7 +213,10 @@ function initializeFeederGrid() {
       numeric: false,
       previousNext: false,
       messages: {
-        display: "Showing {2} feeders"
+        // Public leaderboard intentionally does not surface the total feeder count while the
+        // count is being stabilized (ghost-feeder dedupe + beast-only inclusion). The underlying
+        // data is unchanged; only the plain-sight number is hidden. See AX-957.
+        display: "Feeders"
       }
     },
     sort: function (e) {


### PR DESCRIPTION
## Summary

The public leaderboard pager rendered an aggregate "Showing N feeders" total. The aggregate count could not be guaranteed accurate, so it is being removed from the public leaderboard until it can be reported reliably. Per-feeder rows and the underlying data are unchanged.

## Impact

The public leaderboard no longer shows an aggregate feeder count. Individual feeder rows still render. The aggregate count can be restored once it can be reported reliably.
