### PR TITLE
AX-957 - Clear the leaderboard aggregate count label

### DIFF
--- a/html/leaderboard/feeder-block.init.js
+++ b/html/leaderboard/feeder-block.init.js
@@ -215,8 +215,8 @@ function initializeFeederGrid() {
       messages: {
         // Public leaderboard intentionally does not surface the total feeder count while the
         // count is being stabilized (ghost-feeder dedupe + beast-only inclusion). The underlying
-        // data is unchanged; only the plain-sight number is hidden. See AX-957.
-        display: "Feeders"
+        // data is unchanged; the pager label is blanked so nothing is shown where the count was. See AX-957.
+        display: ""
       }
     },
     sort: function (e) {


### PR DESCRIPTION
## Summary

Follow-up to #145. Sets the pager label to an empty string so no text is rendered where the aggregate feeder total used to be, rather than a placeholder word.

## Impact

The public leaderboard pager renders nothing where the aggregate count was. Leaderboard data and API responses are unchanged.
