### PR TITLE
AX-957 - Remove aggregate feeder count from the public leaderboard

### DIFF
--- a/html/leaderboard/feeder-block.init.js
+++ b/html/leaderboard/feeder-block.init.js
@@ -213,7 +213,9 @@ function initializeFeederGrid() {
       numeric: false,
       previousNext: false,
       messages: {
-        display: "Showing {2} feeders"
+        // The aggregate feeder count is not shown on the public leaderboard until it can be
+        // reported reliably. Per-feeder rows and the underlying data are unchanged. See AX-957.
+        display: ""
       }
     },
     sort: function (e) {


### PR DESCRIPTION
## Summary

Promotes the leaderboard pager change from dev to master for production deployment. The public leaderboard pager no longer renders an aggregate feeder count; the count could not be guaranteed accurate, so it is removed until it can be reported reliably. Per-feeder rows and the underlying data are unchanged.

## Impact

The public leaderboard (globe.adsbexchange.com/leaderboard) shows no aggregate feeder count after deploy. Ships to the prod globe via the adsbexchange_app-prod build and the globe-tar1090 pipeline.
