### PR TITLE
AX-1044 - Disallow crawling of globe history data paths

### DIFF
--- a/html/robots.txt
+++ b/html/robots.txt
@@ -1,7 +1,9 @@
 User-agent: *
+Allow: /ads.txt
 Disallow: /api/
 Disallow: /mapproxy/
 Disallow: /re-api/
+Disallow: /globe_history/
 
 # Allow all static pages
 Allow: /$


### PR DESCRIPTION
## Summary

Adds `Disallow: /globe_history/` to `html/robots.txt`, and adds the `Allow: /ads.txt` line so this copy matches the one in `adsbexchange-app` (`globe/services/globe/opt/html/robots.txt`) byte for byte.

The `/globe_history/` paths serve heatmap and trace data for the tar1090 browser app. Crawlers currently fetch them; the largest is Mediapartners-Google at roughly 1.6 GB/day of heatmap chunks.

Both copies of this file land at `/opt/html/robots.txt` on the globe box. A full `globe` component deploy runs `deploy_tar1090` and then `deploy_globe`, so the adsbexchange-app copy is written last; a `globe-tar1090` partial deploy writes only this copy. Keeping the two identical means the served file is the same whichever deploy ran most recently.

Companion change: ADSBexchange/adsbexchange-app#154

## Impact

Crawler-facing only. No change to the app, and no effect on browser requests — robots.txt is advisory and is not read by tar1090.