### PR TITLE
AX-1044 - Disallow crawling of globe history data paths (master)

### DIFF
--- a/html/robots.txt
+++ b/html/robots.txt
@@ -1,7 +1,9 @@
 User-agent: *
+Allow: /ads.txt
 Disallow: /api/
 Disallow: /mapproxy/
 Disallow: /re-api/
+Disallow: /globe_history/
 
 # Allow all static pages
 Allow: /$


### PR DESCRIPTION
## Summary

Cherry-pick of the `dev` change (#148) onto `master` so the prod build carries it.

Adds `Disallow: /globe_history/` to `html/robots.txt`, plus the `Allow: /ads.txt` line so this copy matches `adsbexchange-app`'s `globe/services/globe/opt/html/robots.txt` byte for byte. Both files now resolve to blob `749e8f6`.

The `/globe_history/` paths serve heatmap and trace data for the tar1090 browser app. Crawlers currently fetch them; the largest is Mediapartners-Google at roughly 1.6 GB/day of heatmap chunks.

Both copies land at `/opt/html/robots.txt` on the globe box. A full `globe` deploy runs `deploy_tar1090` then `deploy_globe`, so the adsbexchange-app copy is written last; the `globe-tar1090` partial writes only this one. On prod the last full `globe` deploy was 2025-10-23 and the last `globe-tar1090` was 2026-07-08, which is why the live file currently matches this copy. Keeping the two identical makes the served file the same either way.

Companion: ADSBexchange/adsbexchange-app#155

## Impact

Crawler-facing only. No change to the app, and no effect on browser requests — robots.txt is advisory and is not read by tar1090.