### PR TITLE
Add Turnstile gate for globe_history trace/heatmap access

### DIFF
--- a/html/config-turnstile.js.tmpl
+++ b/html/config-turnstile.js.tmpl
@@ -1,0 +1,4 @@
+// Rendered from adsbexchange-app deploy-wrapper/conf/global.ini. Empty site key
+// (the default outside ADSBx globe) leaves the historical-data gate inert.
+turnstileSiteKey = '__TURNSTILE_SITE_KEY__';
+turnstileEnforce = __TURNSTILE_ENFORCE__;

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -481,3 +481,8 @@ let enableMostWatchedFilter = false;
 let enableMostWatchedClickTracking = false;
 let enableActiveDates = false;
 let globeDataBaseUrl = '';
+
+// Historical-data (globe_history) Turnstile gate. Empty site key = inert; the
+// rendered config-turnstile.js overrides these on ADSBx globe deployments.
+let turnstileSiteKey = '';
+let turnstileEnforce = false;

--- a/html/index.html
+++ b/html/index.html
@@ -1271,6 +1271,8 @@
     <script src="config.js"></script>
     <script src="config-uav.js"></script>
     <script src="config-feature-flags.js"></script>
+    <script src="config-turnstile.js"></script>
+    <script src="turnstile-gate.js"></script>
     <script src="dbloader.js"></script>
     <script src="registrations.js"></script>
     <script src="formatter.js"></script>

--- a/html/script.js
+++ b/html/script.js
@@ -7690,15 +7690,15 @@ function getTrace(newPlane, hex, options) {
 
         // Historical-data gate: a 403 on a globe_history request means the access
         // token is missing or expired. Re-mint once and resume. The one-shot
-        // options._ghRetried guard prevents a retry storm; a single re-mint fixes
+        // options._globeGateRetried guard prevents a retry storm; a single re-mint fixes
         // the cookie for every following request. For a bulk list this resumes at
         // the next item (getTrace pops from options.list) rather than re-fetching
         // the failed one — acceptable, since the point is to re-arm the cookie.
-        if (jqxhr && jqxhr.status === 403 && options._historic && !options._ghRetried
-            && typeof ghGateActive === 'function' && ghGateActive()) {
-            options._ghRetried = true;
+        if (jqxhr && jqxhr.status === 403 && options._historic && !options._globeGateRetried
+            && typeof globeGateActive === 'function' && globeGateActive()) {
+            options._globeGateRetried = true;
             const retryHex = options.plane;
-            ghEnsureToken(true).then(function() {
+            globeEnsureToken(true).then(function() {
                 getTrace(options.list ? null : g.planes[retryHex], retryHex, options);
             });
             return;

--- a/html/script.js
+++ b/html/script.js
@@ -7587,13 +7587,16 @@ function getTrace(newPlane, hex, options) {
         URL1 = null;
         URL2 = 'globe_history/' + zDateString(refDate).replace(/-/g, '/') + '/traces/' + hex.slice(-2) + '/trace_full_' + hex + '.json';
         traceRate += 3;
+        options._historic = true;
     } else {
         URL1 = 'data/traces/'+ hex.slice(-2) + '/trace_recent_' + hex + '.json';
         URL2 = 'data/traces/'+ hex.slice(-2) + '/trace_full_' + hex + '.json';
         traceRate += 2;
+        options._historic = false;
     }
     if (showTrace && trace_hist_only) {
         URL2 = 'globe_history/' + zDateString(refDate).replace(/-/g, '/') + '/traces/' + hex.slice(-2) + '/trace_full_' + hex + '.json';
+        options._historic = true;
     }
 
     traceOpts.follow = (options.follow == true);
@@ -7680,9 +7683,27 @@ function getTrace(newPlane, hex, options) {
         options.defer = null;
         this.options = null;
     })
-        .fail(function() {
+        .fail(function(jqxhr) {
         const options = this.options;
+        this.options = null;
         const plane = g.planes[options.plane];
+
+        // Historical-data gate: a 403 on a globe_history request means the access
+        // token is missing or expired. Re-mint once and resume. The one-shot
+        // options._ghRetried guard prevents a retry storm; a single re-mint fixes
+        // the cookie for every following request. For a bulk list this resumes at
+        // the next item (getTrace pops from options.list) rather than re-fetching
+        // the failed one — acceptable, since the point is to re-arm the cookie.
+        if (jqxhr && jqxhr.status === 403 && options._historic && !options._ghRetried
+            && typeof ghGateActive === 'function' && ghGateActive()) {
+            options._ghRetried = true;
+            const retryHex = options.plane;
+            ghEnsureToken(true).then(function() {
+                getTrace(options.list ? null : g.planes[retryHex], retryHex, options);
+            });
+            return;
+        }
+
         if (showTrace)
             legShift(0, plane);
         else
@@ -7694,7 +7715,6 @@ function getTrace(newPlane, hex, options) {
             plane.getAircraftData();
             refreshSelected();
         }
-        this.options = null;
     });
 
     return newPlane;

--- a/html/turnstile-gate.js
+++ b/html/turnstile-gate.js
@@ -1,7 +1,7 @@
 // Historical-data access gate (client half).
 //
 // On the ADSBx globe, historical trace/heatmap files under /globe_history/ are
-// protected by the globe-history-gate Cloudflare Worker: a request needs a
+// protected by the globe-turnstile Cloudflare Worker: a request needs a
 // short-lived signed cookie that is only issued after a Cloudflare Turnstile
 // challenge. This module obtains that cookie on page load and refreshes it
 // before it expires, so a real browser transparently keeps access while bulk

--- a/html/turnstile-gate.js
+++ b/html/turnstile-gate.js
@@ -1,0 +1,194 @@
+// Historical-data access gate (client half).
+//
+// On the ADSBx globe, historical trace/heatmap files under /globe_history/ are
+// protected by the globe-history-gate Cloudflare Worker: a request needs a
+// short-lived signed cookie that is only issued after a Cloudflare Turnstile
+// challenge. This module obtains that cookie on page load and refreshes it
+// before it expires, so a real browser transparently keeps access while bulk
+// scrapers (which never run the challenge) do not.
+//
+// It is inert unless `turnstileSiteKey` is a real key: on upstream tar1090
+// installs and non-globe deployments the whole module is a no-op, and the
+// exported helpers behave as pass-throughs. Enabled-state is resolved lazily at
+// startup (DOMContentLoaded), after all config-*.js globals have loaded, so this
+// file's position in the script order does not matter.
+//
+// Exports (globals, since tar1090 has no module system):
+//   ghTokenReady          - Promise, resolves once an initial token attempt
+//                           settles (or immediately when disabled)
+//   ghEnsureToken(force)  - Promise, mint a token now (called on a 403)
+//   ghGateActive()        - bool, whether the gate is active on this page
+//   ghEnforcing()         - bool, whether access should block on a token
+
+"use strict";
+
+var ghTokenReady;
+
+(function () {
+    var TOKEN_ENDPOINT = '/gh-token';
+    var TURNSTILE_API = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    var REFRESH_MARGIN_MS = 5 * 60 * 1000; // re-mint 5 min before expiry
+    var RETRY_DELAY_MS = 60 * 1000;        // back off after a failed attempt
+
+    var enabled = false;
+    var enforce = false;
+    var apiLoading = null;
+    var widgetId = null;
+    var executedOnce = false;
+    var attempt = null;      // { settle, timer } for the challenge currently running
+    var inFlight = null;
+    var refreshTimer = null;
+    var readyResolvedOnce = false;
+    var resolveReady;
+
+    ghTokenReady = new Promise(function (res) { resolveReady = res; });
+
+    function settleReadyOnce() {
+        if (!readyResolvedOnce) { readyResolvedOnce = true; resolveReady(); }
+    }
+
+    function computeEnabled() {
+        var k = (typeof turnstileSiteKey !== 'undefined') ? turnstileSiteKey : '';
+        // Guard against an unrendered template placeholder ("__TURNSTILE_SITE_KEY__").
+        enabled = !!k && k.indexOf('__') !== 0;
+        enforce = enabled && (typeof turnstileEnforce !== 'undefined') && turnstileEnforce === true;
+    }
+
+    // Settles the challenge currently in flight, exactly once.
+    function settleAttempt(err, token) {
+        if (!attempt) return;
+        var a = attempt;
+        attempt = null;
+        if (a.timer) clearTimeout(a.timer);
+        if (err) a.reject(err); else a.resolve(token);
+    }
+
+    function loadTurnstileApi() {
+        if (apiLoading) return apiLoading;
+        apiLoading = new Promise(function (resolve, reject) {
+            // interaction-only + execution:execute keeps the widget hidden until a
+            // challenge genuinely needs interaction, so keep the container in the
+            // layout (not display:none) in case that rare fallback UI appears.
+            var container = document.getElementById('turnstile-gate-container');
+            if (!container) {
+                container = document.createElement('div');
+                container.id = 'turnstile-gate-container';
+                container.style.position = 'fixed';
+                container.style.bottom = '0';
+                container.style.right = '0';
+                container.style.zIndex = '2000';
+                document.body.appendChild(container);
+            }
+            window.ghOnTurnstileLoad = function () {
+                try {
+                    widgetId = window.turnstile.render('#turnstile-gate-container', {
+                        sitekey: turnstileSiteKey,
+                        execution: 'execute',
+                        appearance: 'interaction-only',
+                        callback: function (token) { settleAttempt(null, token); },
+                        'error-callback': function () { settleAttempt(new Error('turnstile error')); return true; },
+                        'timeout-callback': function () { settleAttempt(new Error('turnstile timeout')); }
+                    });
+                    resolve(widgetId);
+                } catch (e) {
+                    reject(e);
+                }
+            };
+            var s = document.createElement('script');
+            s.src = TURNSTILE_API + '&onload=ghOnTurnstileLoad';
+            s.async = true;
+            s.defer = true;
+            s.onerror = function () { reject(new Error('turnstile api load failed')); };
+            document.head.appendChild(s);
+        });
+        return apiLoading;
+    }
+
+    // Runs the (deferred) Turnstile challenge and resolves with a fresh response
+    // token delivered to the render-level callback.
+    function getTurnstileToken() {
+        return loadTurnstileApi().then(function () {
+            return new Promise(function (resolve, reject) {
+                // Only one challenge at a time; abandon any prior wait.
+                settleAttempt(new Error('superseded'));
+                attempt = {
+                    resolve: resolve,
+                    reject: reject,
+                    timer: setTimeout(function () { settleAttempt(new Error('turnstile timeout')); }, 30000)
+                };
+                try {
+                    if (executedOnce) window.turnstile.reset(widgetId);
+                    window.turnstile.execute(widgetId);
+                    executedOnce = true;
+                } catch (e) {
+                    settleAttempt(e);
+                }
+            });
+        });
+    }
+
+    function scheduleRefresh(expEpochSec) {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        var msUntil = (expEpochSec * 1000) - Date.now() - REFRESH_MARGIN_MS;
+        if (msUntil < 0) msUntil = RETRY_DELAY_MS;
+        refreshTimer = setTimeout(function () { doMint(); }, msUntil);
+    }
+
+    function backoff() {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        refreshTimer = setTimeout(function () { doMint(); }, RETRY_DELAY_MS);
+    }
+
+    function doMint() {
+        if (!enabled) { settleReadyOnce(); return Promise.resolve(); }
+        if (inFlight) return inFlight;
+        inFlight = getTurnstileToken().then(function (token) {
+            return fetch(TOKEN_ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ token: token }),
+                credentials: 'same-origin'
+            });
+        }).then(function (resp) {
+            return resp.json().catch(function () { return {}; }).then(function (data) {
+                if (resp.ok && data && data.ok && data.exp) {
+                    scheduleRefresh(data.exp);
+                } else {
+                    // Config/verification problem: retry later without wedging the
+                    // page. In log-only mode this has no user impact; in enforce
+                    // mode the fetch path surfaces a 403 and re-triggers a mint.
+                    backoff();
+                }
+                return data;
+            });
+        }).catch(function () {
+            backoff();
+        }).then(function (v) {
+            inFlight = null;
+            settleReadyOnce();
+            return v;
+        });
+        return inFlight;
+    }
+
+    window.ghGateActive = function () { return enabled; };
+    window.ghEnforcing = function () { return enforce; };
+
+    window.ghEnsureToken = function (force) {
+        if (!enabled) return Promise.resolve();
+        if (force && !inFlight && refreshTimer) clearTimeout(refreshTimer);
+        return doMint();
+    };
+
+    function start() {
+        computeEnabled();
+        if (!enabled) { settleReadyOnce(); return; }
+        doMint();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();

--- a/html/turnstile-gate.js
+++ b/html/turnstile-gate.js
@@ -14,15 +14,15 @@
 // file's position in the script order does not matter.
 //
 // Exports (globals, since tar1090 has no module system):
-//   ghTokenReady          - Promise, resolves once an initial token attempt
+//   globeTokenReady          - Promise, resolves once an initial token attempt
 //                           settles (or immediately when disabled)
-//   ghEnsureToken(force)  - Promise, mint a token now (called on a 403)
-//   ghGateActive()        - bool, whether the gate is active on this page
-//   ghEnforcing()         - bool, whether access should block on a token
+//   globeEnsureToken(force)  - Promise, mint a token now (called on a 403)
+//   globeGateActive()        - bool, whether the gate is active on this page
+//   globeEnforcing()         - bool, whether access should block on a token
 
 "use strict";
 
-var ghTokenReady;
+var globeTokenReady;
 
 (function () {
     var TOKEN_ENDPOINT = '/turnstile-token';
@@ -41,7 +41,7 @@ var ghTokenReady;
     var readyResolvedOnce = false;
     var resolveReady;
 
-    ghTokenReady = new Promise(function (res) { resolveReady = res; });
+    globeTokenReady = new Promise(function (res) { resolveReady = res; });
 
     function settleReadyOnce() {
         if (!readyResolvedOnce) { readyResolvedOnce = true; resolveReady(); }
@@ -79,7 +79,7 @@ var ghTokenReady;
                 container.style.zIndex = '2000';
                 document.body.appendChild(container);
             }
-            window.ghOnTurnstileLoad = function () {
+            window.globeOnTurnstileLoad = function () {
                 try {
                     widgetId = window.turnstile.render('#turnstile-gate-container', {
                         sitekey: turnstileSiteKey,
@@ -95,7 +95,7 @@ var ghTokenReady;
                 }
             };
             var s = document.createElement('script');
-            s.src = TURNSTILE_API + '&onload=ghOnTurnstileLoad';
+            s.src = TURNSTILE_API + '&onload=globeOnTurnstileLoad';
             s.async = true;
             s.defer = true;
             s.onerror = function () { reject(new Error('turnstile api load failed')); };
@@ -171,10 +171,10 @@ var ghTokenReady;
         return inFlight;
     }
 
-    window.ghGateActive = function () { return enabled; };
-    window.ghEnforcing = function () { return enforce; };
+    window.globeGateActive = function () { return enabled; };
+    window.globeEnforcing = function () { return enforce; };
 
-    window.ghEnsureToken = function (force) {
+    window.globeEnsureToken = function (force) {
         if (!enabled) return Promise.resolve();
         if (force && !inFlight && refreshTimer) clearTimeout(refreshTimer);
         return doMint();

--- a/html/turnstile-gate.js
+++ b/html/turnstile-gate.js
@@ -25,7 +25,7 @@
 var ghTokenReady;
 
 (function () {
-    var TOKEN_ENDPOINT = '/gh-token';
+    var TOKEN_ENDPOINT = '/turnstile-token';
     var TURNSTILE_API = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
     var REFRESH_MARGIN_MS = 5 * 60 * 1000; // re-mint 5 min before expiry
     var RETRY_DELAY_MS = 60 * 1000;        // back off after a failed attempt


### PR DESCRIPTION
## Summary

Adds the client half of the historical-data access gate for the globe.

- New `turnstile-gate.js`: on page load it solves a Cloudflare Turnstile
  challenge (deferred `execution: 'execute'`, `appearance: 'interaction-only'`),
  POSTs the token to the `globe-history-gate` worker at `/gh-token`, and lets the
  worker set the short-lived `gh_tok` cookie. It reads the expiry from the JSON
  response and re-mints ~5 minutes before it lapses.
- `getTrace` gains 403 handling on historical (`globe_history`) requests: a 403
  means the cookie is missing or expired, so it re-mints once and resumes. A
  one-shot per-request guard prevents a retry storm; re-arming the cookie fixes
  every following request.
- New `config-turnstile.js.tmpl` supplies `turnstileSiteKey` and
  `turnstileEnforce`, following the existing `config-uav.js.tmpl` pattern.
  `defaults.js` declares both with inert defaults.

The whole module is a no-op unless `turnstileSiteKey` is a real key. On upstream
tar1090 and non-globe deployments the template renders nothing (or is absent),
so the globe behaves exactly as before.

The existing unused Google reCAPTCHA Enterprise script in `index.html` is left in
place; removing it touches the terms-of-service markup and is better handled
separately.

## Impact

- No behavior change unless the rendered `turnstileSiteKey` is set — which only
  happens through the adsbexchange-app config (dev test key; prod/qa empty).
- In log-only mode the client just mints a cookie in the background; the 403
  retry path is dormant because nothing returns 403 yet. It becomes active when
  the worker's `ENFORCE` is turned on.
- Requires the adsbexchange-app change to render `__TURNSTILE_SITE_KEY__` /
  `__TURNSTILE_ENFORCE__`; the raw template tokens are inert placeholders the
  gate treats as "disabled", but the two should merge together.
- Existing tar1090 test suite (`node --test`) passes; `turnstile-gate.js` and
  `script.js` pass `node --check`.
